### PR TITLE
Move isort.args outside [python] block

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ You can enable import sorting on save for python by having the following values 
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
     },
-    "isort.args":["--profile", "black"]
   }
+  "isort.args":["--profile", "black"]
 ```
 
 ### Disabling `isort` extension


### PR DESCRIPTION
Moved isort.args outside of python block.

When I had it as orignially documented in my settings.json I'm given an error stating "This setting does not support per-language configuration"  Also, setting it via the settings UI places this outside the python block.