### PR TITLE
Reduce severity of import organization to hints

### DIFF
--- a/bundled/tool/server.py
+++ b/bundled/tool/server.py
@@ -461,7 +461,7 @@ def _get_default_settings(workspace_path: str) -> Dict[str, str]:
         "logLevel": "error",
         "args": [],
         "severity": {
-            "E": "Warning",
+            "E": "Hint",
             "W": "Warning",
         },
         "path": [],

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
                 "isort.severity": {
                     "default": {
                         "W": "Warning",
-                        "E": "Warning"
+                        "E": "Hint"
                     },
                     "additionalProperties": {
                         "type": "string",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -19,7 +19,7 @@ export interface ISettings {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const DEFAULT_SEVERITY: Record<string, string> = { W: 'Warning', E: 'Warning' };
+const DEFAULT_SEVERITY: Record<string, string> = { W: 'Warning', E: 'Hint' };
 
 export async function getExtensionSettings(namespace: string, includeInterpreter?: boolean): Promise<ISettings[]> {
     const settings: ISettings[] = [];

--- a/src/test/python_tests/test_sort.py
+++ b/src/test/python_tests/test_sort.py
@@ -80,7 +80,7 @@ def test_code_actions(action_type):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -109,7 +109,7 @@ def test_code_actions(action_type):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -144,7 +144,7 @@ def test_code_actions(action_type):
                                             "end": {"line": 1, "character": 0},
                                         },
                                         "message": "Imports are incorrectly sorted and/or formatted.",
-                                        "severity": 2,
+                                        "severity": 4,
                                         "code": "E",
                                         "source": "isort",
                                     }
@@ -172,7 +172,7 @@ def test_code_actions(action_type):
                                             "end": {"line": 1, "character": 0},
                                         },
                                         "message": "Imports are incorrectly sorted and/or formatted.",
-                                        "severity": 2,
+                                        "severity": 4,
                                         "code": "E",
                                         "source": "isort",
                                     }
@@ -283,7 +283,7 @@ def test_organize_import(line_ending):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -307,7 +307,7 @@ def test_organize_import(line_ending):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -337,7 +337,7 @@ def test_organize_import(line_ending):
                                         "end": {"line": 1, "character": 0},
                                     },
                                     "message": "Imports are incorrectly sorted and/or formatted.",
-                                    "severity": 2,
+                                    "severity": 4,
                                     "code": "E",
                                     "source": "isort",
                                 }
@@ -443,7 +443,7 @@ def test_organize_import_cell(line_ending):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -467,7 +467,7 @@ def test_organize_import_cell(line_ending):
                                     "end": {"line": 1, "character": 0},
                                 },
                                 "message": "Imports are incorrectly sorted and/or formatted.",
-                                "severity": 2,
+                                "severity": 4,
                                 "code": "E",
                                 "source": "isort",
                             }
@@ -497,7 +497,7 @@ def test_organize_import_cell(line_ending):
                                         "end": {"line": 1, "character": 0},
                                     },
                                     "message": "Imports are incorrectly sorted and/or formatted.",
-                                    "severity": 2,
+                                    "severity": 4,
                                     "code": "E",
                                     "source": "isort",
                                 }

--- a/src/test/ts_tests/tests/common/settings.unit.test.ts
+++ b/src/test/ts_tests/tests/common/settings.unit.test.ts
@@ -12,7 +12,7 @@ import { EXTENSION_ROOT_DIR } from '../../../../common/constants';
 import { getWorkspaceSettings, ISettings } from '../../../../common/settings';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const DEFAULT_SEVERITY: Record<string, string> = { W: 'Warning', E: 'Warning' };
+const DEFAULT_SEVERITY: Record<string, string> = { W: 'Warning', E: 'Hint' };
 
 suite('Settings Tests', () => {
     suite('getWorkspaceSettings tests', () => {


### PR DESCRIPTION
Based on feedback from users, the severity level of imports is now reduced to `hints`.