### PR TITLE
Fix mistype on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note:
 
 ## Usage
 
-Once installed in pyVisual Studio Code, the extension will register `isort` as import organizer. You can use keyboard short cut `shift` + `alt` + `O` to trigger organize imports editor action. You can also trigger this from the quick fix available when imports are not organized.
+Once installed in Visual Studio Code, the extension will register `isort` as import organizer. You can use keyboard short cut `shift` + `alt` + `O` to trigger organize imports editor action. You can also trigger this from the quick fix available when imports are not organized.
 
 ![Fixing import sorting with a code action.](images/vscode-isort.gif)
 


### PR DESCRIPTION
This is a fix for what I think was a small mistype introduced on [this commit](https://github.com/microsoft/vscode-isort/commit/058ef9413c3e6934e26093818264ed6993694a10).

It currently looks a bit weird on the extension description in VSCode:
![image](https://user-images.githubusercontent.com/49994083/204868019-61839302-85a2-4915-94ac-1f9e9ea0d5b3.png)
