### PR TITLE
Use Dependabot on local Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,20 @@ updates:
     labels:
       - 'no-changelog'
 
+  - package-ecosystem: 'github-actions'
+    directory: .github/actions/lint
+    schedule:
+      interval: monthly
+    labels:
+      - 'no-changelog'
+
+  - package-ecosystem: 'github-actions'
+    directory: .github/actions/build-vsix
+    schedule:
+      interval: monthly
+    labels:
+      - 'no-changelog'
+
   - package-ecosystem: 'pip'
     directory: /src/test/python_tests
     schedule:


### PR DESCRIPTION
Unfortunately, Dependabot doesn't pick up local Actions automatically so you need to point to them explicitly.
This should help eliminating (all?) deprecation warnings in CI jobs:

![image](https://user-images.githubusercontent.com/12860284/214983410-5debefd8-ec1b-490b-ad9c-bb19b1efa4f9.png)
