### PR TITLE
Do not log traceback if file has `skip_file` comment

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -650,9 +650,12 @@ def _run_tool_on_document(
                 cwd=cwd,
                 source=source,
             )
+        except isort.exceptions.FileSkipComment:
+            log_warning(f"Skipping file with 'isort:skip_file' comment: {document.path}")
+            return None
         except isort.exceptions.FileSkipped:
             log_warning(traceback.format_exc(chain=True))
-            # Ignore file skipped.
+            return None
         except Exception:
             log_error(traceback.format_exc(chain=True))
             raise

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -651,7 +651,7 @@ def _run_tool_on_document(
                 source=source,
             )
         except isort.exceptions.FileSkipComment:
-            log_warning(f"Skipping file with 'isort:skip_file' comment: {document.path}")
+            log_warning(f"Skipping file with 'skip_file' comment: {document.path}")
             return None
         except isort.exceptions.FileSkipped:
             log_warning(traceback.format_exc(chain=True))


### PR DESCRIPTION
closes #415 

Let's assume you have a file with a [`# isort: skip_file` comment](https://pycqa.github.io/isort/docs/configuration/action_comments.html#isort-skip_file).

### Before:

You'd get a nearly illegible traceback:

<img width="386" alt="Screenshot 2024-07-05 at 12 07 56 AM" src="https://github.com/microsoft/vscode-isort/assets/58642383/e8b1fd84-7dda-471d-8259-2aeaefd06ae5">

### After:
<img width="384" alt="Screenshot 2024-07-05 at 12 37 49 AM" src="https://github.com/microsoft/vscode-isort/assets/58642383/818599b6-fe6d-4d12-8188-1b6acf0027a6">

