### PR TITLE
Check for `None` on `_run_tool_on_document`

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -307,7 +307,7 @@ def is_interactive(file_path: str) -> bool:
 
 def _formatting_helper(document: workspace.Document) -> list[lsp.TextEdit] | None:
     result = _run_tool_on_document(document, use_stdin=True)
-    if result.stdout:
+    if result and result.stdout:
         new_source = _match_line_endings(document, result.stdout)
 
         # Skip last line ending in a notebook cell


### PR DESCRIPTION
`_formatting_helper` calls `_run_tool_on_document` and immediately accesses `result.stdout` without checking if result is `None`. In multi-root workspaces, files that don't fall under any workspace folder resolve to fallback settings that run isort in-process — the only execution branch where `FileSkipped`/`FileSkipComment` exceptions cause a `None` return. This results in an `AttributeError` that crashes the LSP server and hangs VS Code.

`_linting_helper` already handles this correctly with `if result and result.stderr`, but `_formatting_helper` was never given the same treatment.

## Solution
Add a `None` check in `_formatting_helper` before accessing `result.stdout.`

Fixes #362