### PR TITLE
Agentic Workflow: Extension template sync

### DIFF
--- a/.github/workflows/extension-template-sync.lock.yml
+++ b/.github/workflows/extension-template-sync.lock.yml
@@ -23,7 +23,7 @@
 #
 # Daily check (and on-demand trigger) to sync changes from the upstream microsoft/vscode-python-tools-extension-template into this repository. Reads recently merged PRs from the template, determines whether the changes apply to this repo, and opens a sync PR if they do.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"4b05c87401cb781cfeae5362abdcc9ea1bb6fccb6543505ba6fa2e82ae32da64","compiler_version":"v0.47.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"6848419a8d302e6fe5a6b3d24dbd1208071251f9a70212097c73ef3313f4a4d2","compiler_version":"v0.47.5"}
 
 name: 'Extension Template Sync'
 'on':
@@ -287,6 +287,10 @@ jobs:
           destination: /opt/gh-aw/actions
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Checkout template repo
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/extension-template-sync.md
+++ b/.github/workflows/extension-template-sync.md
@@ -28,6 +28,10 @@ safe-outputs:
   noop:
     max: 1
 steps:
+- name: Checkout repository
+  uses: actions/checkout@v5
+  with:
+    persist-credentials: false
 - name: Checkout template repo
   uses: actions/checkout@v5
   with:


### PR DESCRIPTION
Adds a new agentic workflow (\xtension-template-sync.md\) that keeps this repository in sync with the upstream [vscode-python-tools-extension-template](https://github.com/microsoft/vscode-python-tools-extension-template).

### How it works
- **Daily schedule**: Checks for PRs merged in the template repo within the last 24 hours and opens a sync PR if any changes are relevant.
- **On-demand**: Can be triggered manually via \workflow_dispatch\ with a specific template PR number.

The agent reads the template PR diff, determines which files are shared vs. tool-specific, applies applicable changes while preserving isort-specific customizations, and opens a draft PR for review.