### PR TITLE
Enable publishing by default in pre-release pipeline

### DIFF
--- a/build/azure-devdiv-pipeline.pre-release.yml
+++ b/build/azure-devdiv-pipeline.pre-release.yml
@@ -33,7 +33,7 @@ parameters:
   - name: publishExtension
     displayName: 🚀 Publish Extension
     type: boolean
-    default: false
+    default: true
 
   - name: buildSteps
     type: stepList


### PR DESCRIPTION
Change the `publishExtension` parameter default from `false` to `true` in the pre-release pipeline, so that publishing is enabled by default when the pipeline runs.

### Change
- `build/azure-devdiv-pipeline.pre-release.yml`: `default: false` → `default: true`