### PR TITLE
Fix Pygls 2.0 test mock names and add onNotebook activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "activationEvents": [
         "onLanguage:python",
         "workspaceContains:pyproject.toml",
-        "workspaceContains:.isort"
+        "workspaceContains:.isort",
+        "onNotebook:jupyter-notebook",
+        "onNotebook:interactive"
     ],
     "main": "./dist/extension.js",
     "l10n": "./l10n",

--- a/src/test/python_tests/test_get_cwd.py
+++ b/src/test/python_tests/test_get_cwd.py
@@ -23,10 +23,10 @@ def _setup_mocks():
         def command(self, *args, **kwargs):
             return lambda f: f
 
-        def show_message_log(self, *args, **kwargs):
+        def window_log_message(self, *args, **kwargs):
             pass
 
-        def show_message(self, *args, **kwargs):
+        def window_show_message(self, *args, **kwargs):
             pass
 
     mock_server = types.ModuleType("pygls.lsp.server")
@@ -71,6 +71,7 @@ def _setup_mocks():
         "DidSaveNotebookDocumentParams",
         "InitializeParams",
         "LogMessageParams",
+        "ShowMessageParams",
         "NotebookCellKind",
         "NotebookCellLanguage",
         "NotebookDocumentFilterWithNotebook",


### PR DESCRIPTION
## Summary

- Rename `show_message_log` → `window_log_message` and `show_message` → `window_show_message` in the `_MockLS` test stub to match Pygls 2.0 API
- Add `ShowMessageParams` to the mocked LSP type stubs
- Add `onNotebook:jupyter-notebook` and `onNotebook:interactive` activation events to `package.json`

Closes #580