### PR TITLE
Update validation triggers

### DIFF
--- a/build/azure-pipeline.validation.yml
+++ b/build/azure-pipeline.validation.yml
@@ -3,18 +3,12 @@
 trigger:
   branches:
     include:
-      - main
-      - release
-      - release/*
-      - release-*
+      - '*'
 
 pr:
   branches:
     include:
-      - main
-      - release
-      - release/*
-      - release-*
+      - '*'
   drafts: false
 
 resources:


### PR DESCRIPTION
This pull request makes a small update to the Azure Pipeline configuration. The branch filters for both trigger and PR events have been broadened to include all branches, rather than just a select few.

* The `trigger` and `pr` branch filters in `build/azure-pipeline.validation.yml` were changed from specific branch names and patterns to a wildcard (`'*'`), so the pipeline will now run for any branch.