### PR TITLE
Refactor: add RunResult exit_code and align lsp_runner sys.path

### DIFF
--- a/bundled/tool/lsp_runner.py
+++ b/bundled/tool/lsp_runner.py
@@ -23,8 +23,11 @@ def update_sys_path(path_to_add: str, strategy: str) -> None:
 
 
 # Ensure that we can import LSP libraries, and other bundled libraries.
+BUNDLE_DIR = pathlib.Path(__file__).parent.parent
+# Always bundled: this is the server's own code, not a user-swappable dependency.
+update_sys_path(os.fspath(BUNDLE_DIR / "tool"), "useBundled")
 update_sys_path(
-    os.fspath(pathlib.Path(__file__).parent.parent / "libs"),
+    os.fspath(BUNDLE_DIR / "libs"),
     os.getenv("LS_IMPORT_STRATEGY", "useBundled"),
 )
 

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import sysconfig
 import threading
-from typing import Any, Callable, List, Sequence, Tuple, Union
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 # Save the working directory used when loading this module
 SERVER_CWD = os.getcwd()
@@ -88,9 +88,10 @@ def is_stdlib_file(file_path: str) -> bool:
 class RunResult:
     """Object to hold result from running tool."""
 
-    def __init__(self, stdout, stderr):
-        self.stdout = stdout
-        self.stderr = stderr
+    def __init__(self, stdout: str, stderr: str, exit_code: Optional[int] = None):
+        self.stdout: str = stdout
+        self.stderr: str = stderr
+        self.exit_code: Optional[int] = exit_code
 
 
 class CustomIO(io.TextIOWrapper):


### PR DESCRIPTION
## Summary

Two small refactors to align isort's bundled tool infrastructure with the upstream extension template and sibling extensions (black, flake8, pylint).

### Change 1: RunResult.exit_code (lsp_utils.py)

Add an \xit_code: Optional[Union[int, str]] = None\ parameter to \RunResult.__init__\, matching mypy's implementation pattern. The default of \None\ keeps this fully backward-compatible — all existing callers continue to work unchanged.

### Change 2: lsp_runner.py sys.path setup

Add the missing \	ool\ directory to \sys.path\ via a new \BUNDLE_DIR\ variable, matching the pattern used by black, flake8, and pylint runners. Isort's runner was the only one missing this path entry, which could cause import failures when the runner is invoked under a different interpreter.

---

Part of #620
Ref: microsoft/vscode-python-tools-extension-template#290