### PR TITLE
Refactor: merge vscodeapi.ts to cross-repo superset

### DIFF
--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
     commands,
     ConfigurationScope,
     Disposable,
+    DocumentFormattingEditProvider,
     languages,
     LanguageStatusItem,
     LogOutputChannel,
-    TextEditor,
+    StatusBarAlignment,
+    StatusBarItem,
     Uri,
     window,
     workspace,
@@ -31,6 +34,7 @@ export function registerCommand(command: string, callback: (...args: any[]) => a
 }
 
 export const { onDidChangeConfiguration } = workspace;
+export const { onDidChangeActiveTextEditor } = window;
 
 export function isVirtualWorkspace(): boolean {
     const isVirtual = workspace.workspaceFolders && workspace.workspaceFolders.every((f) => f.uri.scheme !== 'file');
@@ -45,10 +49,17 @@ export function getWorkspaceFolder(uri: Uri): WorkspaceFolder | undefined {
     return workspace.getWorkspaceFolder(uri);
 }
 
+export function registerDocumentFormattingEditProvider(
+    selector: DocumentSelector,
+    provider: DocumentFormattingEditProvider,
+): Disposable {
+    return languages.registerDocumentFormattingEditProvider(selector, provider);
+}
+
 export function createLanguageStatusItem(id: string, selector: DocumentSelector): LanguageStatusItem {
     return languages.createLanguageStatusItem(id, selector);
 }
 
-export function getActiveTextEditor(): TextEditor | undefined {
-    return window.activeTextEditor;
+export function createStatusBarItem(id: string, alignment?: StatusBarAlignment, priority?: number): StatusBarItem {
+    return window.createStatusBarItem(id, alignment ?? StatusBarAlignment.Right, priority);
 }


### PR DESCRIPTION
Merges vscodeapi.ts to the superset of all 5 extension repos. Adds exports for `onDidChangeActiveTextEditor`, `createStatusBarItem` (from pylint), and `registerDocumentFormattingEditProvider` (from black). Removes unused `getActiveTextEditor` export. All new exports are unused wrappers that don't affect runtime behavior.

Part of #620
Ref: microsoft/vscode-python-tools-extension-template#290