### PR TITLE
test: parametrize get_cwd and adopt conftest in path_specialization

### DIFF
--- a/src/test/python_tests/test_get_cwd.py
+++ b/src/test/python_tests/test_get_cwd.py
@@ -10,6 +10,7 @@ import os
 import types
 
 import lsp_server
+import pytest
 
 WORKSPACE = "/home/user/myproject"
 
@@ -73,51 +74,32 @@ DOC_PATH = "/home/user/myproject/src/foo.py"
 DOC = _make_doc(DOC_PATH)
 
 
-def test_file_resolved():
-    settings = _make_settings(cwd="${file}")
-    assert lsp_server.get_cwd(settings, DOC) == DOC_PATH
-
-
-def test_file_basename_resolved():
-    settings = _make_settings(cwd="${fileBasename}")
-    assert lsp_server.get_cwd(settings, DOC) == "foo.py"
-
-
-def test_file_basename_no_extension_resolved():
-    settings = _make_settings(cwd="${fileBasenameNoExtension}")
-    assert lsp_server.get_cwd(settings, DOC) == "foo"
-
-
-def test_file_extname_resolved():
-    settings = _make_settings(cwd="${fileExtname}")
-    assert lsp_server.get_cwd(settings, DOC) == ".py"
-
-
-def test_file_dirname_resolved():
-    settings = _make_settings(cwd="${fileDirname}")
-    assert lsp_server.get_cwd(settings, DOC) == "/home/user/myproject/src"
-
-
-def test_file_dirname_basename_resolved():
-    settings = _make_settings(cwd="${fileDirnameBasename}")
-    assert lsp_server.get_cwd(settings, DOC) == "src"
-
-
-def test_relative_file_resolved():
-    settings = _make_settings(cwd="${relativeFile}")
-    assert lsp_server.get_cwd(settings, DOC) == os.path.relpath(DOC_PATH, WORKSPACE)
-
-
-def test_relative_file_dirname_resolved():
-    settings = _make_settings(cwd="${relativeFileDirname}")
-    assert lsp_server.get_cwd(settings, DOC) == os.path.relpath(
-        "/home/user/myproject/src", WORKSPACE
-    )
-
-
-def test_file_workspace_folder_resolved():
-    settings = _make_settings(cwd="${fileWorkspaceFolder}")
-    assert lsp_server.get_cwd(settings, DOC) == WORKSPACE
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        pytest.param("${file}", DOC_PATH, id="file"),
+        pytest.param("${fileBasename}", "foo.py", id="fileBasename"),
+        pytest.param("${fileBasenameNoExtension}", "foo", id="fileBasenameNoExtension"),
+        pytest.param("${fileExtname}", ".py", id="fileExtname"),
+        pytest.param("${fileDirname}", "/home/user/myproject/src", id="fileDirname"),
+        pytest.param("${fileDirnameBasename}", "src", id="fileDirnameBasename"),
+        pytest.param(
+            "${relativeFile}",
+            os.path.relpath(DOC_PATH, WORKSPACE),
+            id="relativeFile",
+        ),
+        pytest.param(
+            "${relativeFileDirname}",
+            os.path.relpath("/home/user/myproject/src", WORKSPACE),
+            id="relativeFileDirname",
+        ),
+        pytest.param("${fileWorkspaceFolder}", WORKSPACE, id="fileWorkspaceFolder"),
+    ],
+)
+def test_single_variable_resolved(token, expected):
+    """Each VS Code variable token resolves to its expected value."""
+    settings = _make_settings(cwd=token)
+    assert lsp_server.get_cwd(settings, DOC) == expected
 
 
 def test_composite_pattern_resolved():

--- a/src/test/python_tests/test_path_specialization.py
+++ b/src/test/python_tests/test_path_specialization.py
@@ -1,23 +1,16 @@
-"""
-Test for path and interpreter settings.
+"""Test for path and interpreter settings.
+
+Mock LSP dependencies and sys.path setup are provided by conftest.py.
 """
 
 import copy
-import os
 import pathlib
-import sys
 from unittest.mock import MagicMock
 
 from hamcrest import assert_that, is_
+from lsp_server import _get_document_path
 
 from .lsp_test_client import constants, defaults, session, utils
-
-# Add bundled paths so lsp_server and its deps can be imported
-_PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, os.fsdecode(_PROJECT_ROOT / "bundled" / "libs"))
-sys.path.insert(0, os.fsdecode(_PROJECT_ROOT / "bundled" / "tool"))
-
-from lsp_server import _get_document_path
 
 TEST_FILE = constants.TEST_DATA / "sample1" / "sample.py"
 


### PR DESCRIPTION
## Summary

Pytest modernization Round 1 for isort:

- **test_get_cwd.py**: Collapse 9 individual variable-token test functions into a single \@pytest.mark.parametrize\ test. Each VS Code variable (\\\, \\\, etc.) is now a parametrized case. All edge-case, fallback, and notebook document tests are kept as-is.
- **test_path_specialization.py**: Remove inline \sys.path\ manipulation — conftest.py already handles bundled path setup.

Net: 9 → 1 test function (same coverage), cleaner imports.

Part of the pytest modernization effort (Phase 4.4e Round 1).