### PR TITLE
test: parametrize logging and global_defaults tests

### DIFF
--- a/src/test/python_tests/test_global_defaults.py
+++ b/src/test/python_tests/test_global_defaults.py
@@ -9,6 +9,7 @@ Mock setup is provided by conftest.py (setup_lsp_mocks).
 """
 
 import lsp_server
+import pytest
 
 
 def _with_global_settings(overrides, fn):
@@ -23,79 +24,44 @@ def _with_global_settings(overrides, fn):
         lsp_server.GLOBAL_SETTINGS.update(original)
 
 
-def test_check_read_from_global_settings():
-    """_get_global_defaults() returns check from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"check": True},
-        lsp_server._get_global_defaults,
-    )
-    assert result["check"] is True
-
-
-def test_check_defaults_to_false():
-    """_get_global_defaults() returns False when GLOBAL_SETTINGS has no check."""
-    result = _with_global_settings({}, lsp_server._get_global_defaults)
-    assert result["check"] is False
-
-
-def test_path_read_from_global_settings():
-    """_get_global_defaults() returns path from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"path": ["/usr/bin/isort"]},
-        lsp_server._get_global_defaults,
-    )
-    assert result["path"] == ["/usr/bin/isort"]
-
-
-def test_path_defaults_to_empty_list():
-    """_get_global_defaults() returns [] when GLOBAL_SETTINGS has no path."""
-    result = _with_global_settings({}, lsp_server._get_global_defaults)
-    assert result["path"] == []
-
-
-def test_show_notifications_read_from_global_settings():
-    """_get_global_defaults() returns showNotifications from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"showNotifications": "always"},
-        lsp_server._get_global_defaults,
-    )
-    assert result["showNotifications"] == "always"
-
-
-def test_import_strategy_read_from_global_settings():
-    """_get_global_defaults() returns importStrategy from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"importStrategy": "fromEnvironment"},
-        lsp_server._get_global_defaults,
-    )
-    assert result["importStrategy"] == "fromEnvironment"
-
-
-def test_args_read_from_global_settings():
-    """_get_global_defaults() returns args from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"args": ["--profile", "black"]},
-        lsp_server._get_global_defaults,
-    )
-    assert result["args"] == ["--profile", "black"]
-
-
-def test_args_defaults_to_empty_list():
-    """_get_global_defaults() returns [] when GLOBAL_SETTINGS has no args."""
-    result = _with_global_settings({}, lsp_server._get_global_defaults)
-    assert result["args"] == []
-
-
-def test_extra_paths_read_from_global_settings():
-    """_get_global_defaults() returns extraPaths from GLOBAL_SETTINGS."""
-    result = _with_global_settings(
-        {"extraPaths": ["/custom/lib"]},
-        lsp_server._get_global_defaults,
-    )
-    assert result["extraPaths"] == ["/custom/lib"]
-
-
-def test_extra_paths_defaults_to_empty_list():
-    """_get_global_defaults() returns [] when GLOBAL_SETTINGS has no extraPaths."""
-    result = _with_global_settings({}, lsp_server._get_global_defaults)
-    assert result["extraPaths"] == []
+@pytest.mark.parametrize(
+    "overrides, key, expected",
+    [
+        pytest.param({"check": True}, "check", True, id="check-set"),
+        pytest.param({}, "check", False, id="check-default"),
+        pytest.param(
+            {"path": ["/usr/bin/isort"]}, "path", ["/usr/bin/isort"], id="path-set"
+        ),
+        pytest.param({}, "path", [], id="path-default"),
+        pytest.param(
+            {"showNotifications": "always"},
+            "showNotifications",
+            "always",
+            id="showNotifications-set",
+        ),
+        pytest.param(
+            {"importStrategy": "fromEnvironment"},
+            "importStrategy",
+            "fromEnvironment",
+            id="importStrategy-set",
+        ),
+        pytest.param(
+            {"args": ["--profile", "black"]},
+            "args",
+            ["--profile", "black"],
+            id="args-set",
+        ),
+        pytest.param({}, "args", [], id="args-default"),
+        pytest.param(
+            {"extraPaths": ["/custom/lib"]},
+            "extraPaths",
+            ["/custom/lib"],
+            id="extraPaths-set",
+        ),
+        pytest.param({}, "extraPaths", [], id="extraPaths-default"),
+    ],
+)
+def test_global_defaults_setting(overrides, key, expected):
+    """Each global setting is correctly read or defaults when absent."""
+    result = _with_global_settings(overrides, lsp_server._get_global_defaults)
+    assert result[key] == expected

--- a/src/test/python_tests/test_logging.py
+++ b/src/test/python_tests/test_logging.py
@@ -15,6 +15,7 @@ import os
 from unittest.mock import patch
 
 import lsp_server
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -31,130 +32,48 @@ def test_log_to_output_calls_window_log_message(patched_lsp_server):
 
 
 # ---------------------------------------------------------------------------
-# log_error
+# notification gating (log_error / log_warning / log_always)
 # ---------------------------------------------------------------------------
-def test_log_error_always_logs(patched_lsp_server):
-    """log_error always calls window_log_message regardless of notification setting."""
+@pytest.mark.parametrize(
+    "log_func_name, message, notification_setting, expect_show",
+    [
+        pytest.param("log_error", "error occurred", "off", False, id="error-off"),
+        pytest.param(
+            "log_error", "error occurred", "onError", True, id="error-onError"
+        ),
+        pytest.param("log_error", "error occurred", "always", True, id="error-always"),
+        pytest.param("log_warning", "warning message", "off", False, id="warning-off"),
+        pytest.param(
+            "log_warning", "warning message", "onError", False, id="warning-onError"
+        ),
+        pytest.param(
+            "log_warning", "warning message", "onWarning", True, id="warning-onWarning"
+        ),
+        pytest.param(
+            "log_warning", "warning message", "always", True, id="warning-always"
+        ),
+        pytest.param("log_always", "info message", "off", False, id="always-off"),
+        pytest.param(
+            "log_always", "info message", "onError", False, id="always-onError"
+        ),
+        pytest.param(
+            "log_always", "info message", "onWarning", False, id="always-onWarning"
+        ),
+        pytest.param("log_always", "info message", "always", True, id="always-always"),
+    ],
+)
+def test_notification_gating(
+    patched_lsp_server, log_func_name, message, notification_setting, expect_show
+):
+    """Log functions always log; notifications are gated by LS_SHOW_NOTIFICATION."""
     log_mock, show_mock = patched_lsp_server
+    log_func = getattr(lsp_server, log_func_name)
 
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_error("error occurred")
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": notification_setting}):
+        log_func(message)
 
     log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_error_shows_notification_on_error(patched_lsp_server):
-    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_error("error occurred")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-def test_log_error_shows_notification_on_always(patched_lsp_server):
-    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_error("error occurred")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# log_warning
-# ---------------------------------------------------------------------------
-def test_log_warning_no_notification_when_off(patched_lsp_server):
-    """log_warning does not show notification when LS_SHOW_NOTIFICATION=off."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_warning_no_notification_on_error_only(patched_lsp_server):
-    """log_warning does not show notification when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_warning_shows_notification_on_warning(patched_lsp_server):
-    """log_warning shows notification when LS_SHOW_NOTIFICATION=onWarning."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-def test_log_warning_shows_notification_on_always(patched_lsp_server):
-    """log_warning shows notification when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_warning("warning message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# log_always
-# ---------------------------------------------------------------------------
-def test_log_always_no_notification_when_off(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=off."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_no_notification_on_error(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=onError."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_no_notification_on_warning(patched_lsp_server):
-    """log_always does not show notification when LS_SHOW_NOTIFICATION=onWarning."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_not_called()
-
-
-def test_log_always_shows_notification_on_always(patched_lsp_server):
-    """log_always shows notification only when LS_SHOW_NOTIFICATION=always."""
-    log_mock, show_mock = patched_lsp_server
-
-    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
-        lsp_server.log_always("info message")
-
-    log_mock.assert_called_once()
-    show_mock.assert_called_once()
+    if expect_show:
+        show_mock.assert_called_once()
+    else:
+        show_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Pytest modernization Round 2 for isort:

- **test_logging.py**: Collapse 11 notification-gating tests into 1 \@pytest.mark.parametrize\ test covering all log_error/log_warning/log_always × notification setting combinations.
- **test_global_defaults.py**: Collapse 10 setting tests into 1 \@pytest.mark.parametrize\ test covering check/path/showNotifications/importStrategy/args/extraPaths.

Net: 21 → 2 test functions (same coverage).

Part of the pytest modernization effort (Phase 4.4e Round 2).