### PR TITLE
fix: stop excluding dist-info from packaged extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,7 +17,6 @@ vsc-extension-quickstart.md
 **/__pycache__/**
 **/*.pyc
 bundled/libs/bin/**
-bundled/libs/*.dist-info/**
 noxfile.py
 .pytest_cache/**
 .pylintrc

--- a/src/test/python_tests/test_packaging.py
+++ b/src/test/python_tests/test_packaging.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Tests that bundled package metadata is intact.
+
+The extension ships bundled Python packages in ``bundled/libs/``.
+Some packages (e.g. isort 8.x) use ``importlib.metadata`` at runtime
+to resolve their version string, which requires the corresponding
+``.dist-info`` directory to be present.  These tests verify the
+metadata was not accidentally excluded (see issue #649).
+"""
+
+import importlib.metadata
+import pathlib
+import sys
+
+import pytest
+
+BUNDLED_LIBS = pathlib.Path(__file__).parent.parent.parent.parent / "bundled" / "libs"
+
+
+@pytest.fixture(autouse=True)
+def _ensure_bundled_on_path():
+    """Temporarily prepend ``bundled/libs`` to ``sys.path``."""
+    libs = str(BUNDLED_LIBS)
+    if libs not in sys.path:
+        sys.path.insert(0, libs)
+        yield
+        sys.path.remove(libs)
+    else:
+        yield
+
+
+def test_isort_metadata_version():
+    """importlib.metadata must be able to resolve the bundled isort version.
+
+    This is the exact call that ``isort._version`` makes at import time.
+    If the ``isort-*.dist-info`` directory is missing (e.g. stripped by
+    ``.vscodeignore``), this raises ``PackageNotFoundError``.
+    """
+    version = importlib.metadata.version("isort")
+    assert version, "isort version string should not be empty"
+    # Basic sanity: version should look like a PEP 440 version
+    parts = version.split(".")
+    assert len(parts) >= 2, f"Unexpected version format: {version}"


### PR DESCRIPTION
## Problem

isort 8.x uses importlib.metadata.version('isort') in _version.py to determine its version string. This is the modern standard recommended by PEP 566 / PEP 517.

The .vscodeignore had a blanket exclusion undled/libs/*.dist-info/** that stripped all package metadata from the vsix. When the LSP server starts and import isort triggers the metadata lookup, Python raises:

`
importlib.metadata.PackageNotFoundError: No package metadata was found for isort
`

This crashes the server on startup.

## Fix

Remove the undled/libs/*.dist-info/** exclusion entirely. The size impact is negligible (~10-50 KB total) and this future-proofs against any bundled dependency switching to importlib.metadata for versioning.

## Verification

Confirmed with sce ls --no-dependencies that isort-8.0.1.dist-info/ files are now included.

Fixes #649