### PR TITLE
Work around isort comment-placement bug (#712)

### DIFF
--- a/bundled/tool/isort_comment_fix.py
+++ b/bundled/tool/isort_comment_fix.py
@@ -1,0 +1,220 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Workaround for an isort bug where re-wrapping a parenthesized
+multi-import block whose individual names carry trailing inline comments
+(e.g. ``# pyright: ignore[...]``) causes isort to split the block into
+several single-name backslash-continuation lines and relocate the comment
+that was attached to the *opening* ``from X import (`` line onto the
+*last* individual import, semicolon-joined with that import's own
+comment.
+
+Example (isort 8.0.1, zero config)::
+
+    # input
+    from bpy.props import (  # pyright: ignore[reportMissingModuleSource]
+        BoolProperty,  # pyright: ignore[reportUnknownVariableType]
+        EnumProperty,  # pyright: ignore[reportUnknownVariableType]
+        StringProperty,  # pyright: ignore[reportUnknownVariableType]
+    )
+
+    # isort's output (wrong)
+    from bpy.props import \\
+        BoolProperty  # pyright: ignore[reportUnknownVariableType]
+    from bpy.props import \\
+        EnumProperty  # pyright: ignore[reportUnknownVariableType]
+    from bpy.props import \\
+        StringProperty  # pyright: ignore[reportMissingModuleSource]; pyright: ignore[reportUnknownVariableType]
+
+``repair_comment_placement`` detects this exact output shape and rewrites
+it back into a parenthesized block with each name's original comment
+restored to that same name, and the header comment restored to the
+opening ``(`` line. The corrected name *order* is always taken from
+isort's own output (that part isn't broken -- only comment placement is),
+so this never second-guesses a real sorting decision isort made.
+
+This is a workaround for an upstream isort defect, not a full fix -- see
+https://github.com/microsoft/vscode-isort/issues/712 for the report and
+root-cause discussion.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional
+
+# A parenthesized multi-import block in the *original* (pre-isort) source,
+# e.g.:
+#     from bpy.props import (  # header comment
+#         BoolProperty,  # comment
+#         EnumProperty,  # comment
+#     )
+_BLOCK_RE = re.compile(
+    r"^from[ \t]+(?P<module>[\w.]+)[ \t]+import[ \t]*\([ \t]*"
+    r"(?P<header_comment>#[^\n]*)?\n"
+    r"(?P<body>(?:[ \t]+.+\n)+?)"
+    r"\)[ \t]*\n",
+    re.MULTILINE,
+)
+
+# One imported name line inside a block body, e.g.:
+#     "    StringProperty,  # pyright: ignore[reportUnknownVariableType]"
+#     "    Foo as Bar,"
+_NAME_LINE_RE = re.compile(
+    r"^[ \t]+(?P<name>\w+)"
+    r"(?:[ \t]+as[ \t]+(?P<alias>\w+))?"
+    r"[ \t]*,?[ \t]*"
+    r"(?P<comment>#[^\n]*)?[ \t]*\n?$"
+)
+
+# One "unit" of isort's buggy split output. isort produces either shape
+# depending on whether that particular name+comment fits the line length:
+#     from MODULE import \
+#         NAME[ as ALIAS]  [# comment]
+# or, when it fits on one line:
+#     from MODULE import NAME[ as ALIAS]  [# comment]
+# A run can mix both shapes for different names from the same original
+# block, so both must be recognized as the same kind of "unit".
+_BUGGY_UNIT_RE = re.compile(
+    r"^from[ \t]+(?P<module>[\w.]+)[ \t]+import[ \t]*"
+    r"(?:\\\n[ \t]+(?P<full_wrapped>\w+(?:[ \t]+as[ \t]+\w+)?)"
+    r"|(?P<full_plain>\w+(?:[ \t]+as[ \t]+\w+)?))"
+    r"[ \t]*(?:#[^\n]*)?\n",
+    re.MULTILINE,
+)
+
+
+def _normalize(full: str) -> str:
+    return re.sub(r"\s+", " ", full.strip())
+
+
+class _CommentBlock:
+    __slots__ = ("module", "header_comment", "names")
+
+    def __init__(self, module: str, header_comment: Optional[str], names: Dict[str, str]):
+        self.module = module
+        self.header_comment = header_comment
+        self.names = names  # normalized "name" or "name as alias" -> comment or None
+
+
+def _extract_comment_blocks(source: str) -> Dict[str, List[_CommentBlock]]:
+    """Find parenthesized multi-import blocks in ``source`` that have at
+    least one trailing inline comment (on a name, or on the opening ``(``
+    line) -- i.e. blocks isort's bug can affect. Returns module -> list of
+    blocks, in the order they appear in the source."""
+    blocks: Dict[str, List[_CommentBlock]] = {}
+    for m in _BLOCK_RE.finditer(source):
+        body = m.group("body")
+        names: Dict[str, str] = {}
+        ok = True
+        for line in body.splitlines(keepends=True):
+            if not line.strip():
+                continue
+            nm = _NAME_LINE_RE.match(line)
+            if not nm:
+                # Doesn't match our simple one-name-per-line assumption
+                # (e.g. multiple names crammed onto one line) -- skip this
+                # block entirely rather than guess.
+                ok = False
+                break
+            full = nm.group("name")
+            if nm.group("alias"):
+                full = f"{full} as {nm.group('alias')}"
+            names[_normalize(full)] = nm.group("comment")
+        if not ok:
+            continue
+
+        header_comment = m.group("header_comment")
+        if not header_comment and not any(names.values()):
+            continue  # no comments anywhere -> isort's bug doesn't apply
+
+        blocks.setdefault(m.group("module"), []).append(
+            _CommentBlock(m.group("module"), header_comment, names)
+        )
+    return blocks
+
+
+def repair_comment_placement(original_source: str, isort_output: str) -> str:
+    """Return ``isort_output`` with any comment-misplacement caused by the
+    isort bug described in the module docstring corrected, by
+    cross-referencing the original (pre-isort) source.
+
+    Safe to call unconditionally: if nothing in ``original_source`` could
+    have triggered the bug, or the buggy output shape isn't found,
+    ``isort_output`` is returned unchanged.
+    """
+    if "#" not in original_source:
+        # Fast path: the bug can only fire when the original source had a
+        # comment somewhere (on a name or the opening "(" line).
+        return isort_output
+
+    orig = original_source.replace("\r\n", "\n")
+    out = isort_output.replace("\r\n", "\n")
+
+    blocks_by_module = _extract_comment_blocks(orig)
+    if not blocks_by_module:
+        return isort_output
+
+    units = list(_BUGGY_UNIT_RE.finditer(out))
+    if not units:
+        return isort_output
+
+    # Group consecutive (no gap, same module) units into runs -- isort
+    # emits each split-out name back-to-back for the same original block.
+    runs = []
+    i = 0
+    while i < len(units):
+        j = i + 1
+        module = units[i].group("module")
+        while (
+            j < len(units)
+            and units[j].group("module") == module
+            and units[j].start() == units[j - 1].end()
+        ):
+            j += 1
+        runs.append((module, units[i], units[j - 1]))
+        i = j
+
+    # Track how many blocks-per-module we've already consumed, so multiple
+    # occurrences of the same module are matched in source order.
+    consumed = {module: 0 for module in blocks_by_module}
+
+    # Apply fixes back-to-front so earlier string offsets stay valid.
+    for module, first, last in reversed(runs):
+        candidates = blocks_by_module.get(module)
+        if not candidates:
+            continue
+        idx = consumed[module]
+        if idx >= len(candidates):
+            continue
+
+        run_text = out[first.start() : last.end()]
+        names_in_order = [
+            _normalize(um.group("full_wrapped") or um.group("full_plain"))
+            for um in _BUGGY_UNIT_RE.finditer(run_text)
+        ]
+
+        block = candidates[idx]
+        if set(names_in_order) != set(block.names.keys()):
+            # Not a match for this block (e.g. isort merged in an
+            # unrelated same-module import) -- don't guess, leave alone.
+            continue
+        consumed[module] += 1
+
+        lines = [f"from {module} import ("]
+        if block.header_comment:
+            lines[0] += f"  {block.header_comment}"
+        lines[0] += "\n"
+        for full in names_in_order:
+            line = f"    {full},"
+            comment = block.names.get(full)
+            if comment:
+                line += f"  {comment}"
+            lines.append(line + "\n")
+        lines.append(")\n")
+
+        out = out[: first.start()] + "".join(lines) + out[last.end() :]
+
+    # Line-ending normalization back to the document's original style is
+    # already handled by the caller (_match_line_endings), so we return
+    # \n-normalized text here just like isort's own stdout.
+    return out

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -43,6 +43,7 @@ update_sys_path(os.fspath(pathlib.Path(__file__).parent.parent / "tool"), "useBu
 # **********************************************************
 # pylint: disable=wrong-import-position,import-error
 import isort
+import isort_comment_fix
 import lsp_notebook as notebook
 import lsp_utils as utils
 import lsprotocol.types as lsp
@@ -437,7 +438,16 @@ def is_interactive(file_path: str) -> bool:
 def _formatting_helper(document: TextDocument) -> list[lsp.TextEdit] | None:
     result = _run_tool_on_document(document, use_stdin=True)
     if result and result.stdout:
-        new_source = _match_line_endings(document, result.stdout)
+        # Work around an isort bug (microsoft/vscode-isort#712) where
+        # re-wrapping a parenthesized multi-import block whose names carry
+        # trailing inline comments (e.g. `# pyright: ignore[...]`) causes
+        # isort to misplace those comments. See isort_comment_fix.py for
+        # details. This only rewrites output that matches that exact
+        # buggy shape; anything else passes through unchanged.
+        repaired_stdout = isort_comment_fix.repair_comment_placement(
+            document.source, result.stdout
+        )
+        new_source = _match_line_endings(document, repaired_stdout)
 
         # Skip last line ending in a notebook cell
         if document.uri.startswith("vscode-notebook-cell"):

--- a/bundled/tool/tests/test_isort_comment_fix.py
+++ b/bundled/tool/tests/test_isort_comment_fix.py
@@ -1,0 +1,195 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Unit tests for isort_comment_fix.repair_comment_placement.
+
+Regression tests for https://github.com/microsoft/vscode-isort/issues/712
+("Incorrect pyright comment movement"). These tests run the real isort
+engine (not a mock) so they fail loudly if a future isort release changes
+the buggy output shape this workaround targets, or fixes the bug upstream
+(in which case repair_comment_placement should still be a safe no-op).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+# Ensure bundled/tool is on sys.path so we can import the module directly,
+# and run isort with a cwd/config that can't pick up this repo's own
+# pyproject.toml (which sets `profile = "black"` and changes wrap
+# behavior) -- these tests want to exercise isort's *default* config,
+# matching how a typical user project without a profile set would behave.
+_TOOL_DIR = str(pathlib.Path(__file__).parent.parent)
+if _TOOL_DIR not in sys.path:
+    sys.path.insert(0, _TOOL_DIR)
+
+import isort_comment_fix as fix  # noqa: E402
+
+
+def _run_isort(source: str, tmp_path: pathlib.Path, filename: str = "x.py") -> str:
+    """Run the real isort CLI on ``source``, from a directory with no
+    isort config of its own, and return its stdout.
+
+    Writes ``source`` to the target path on disk first: isort's config
+    resolution behaves differently when the ``--filename`` path doesn't
+    physically exist (as it always does for the real extension, which
+    only ever runs against a file the editor has open), so tests must
+    match that or they won't exercise the same code path.
+    """
+    target = tmp_path / filename
+    target.write_text(source)
+    proc = subprocess.run(
+        [sys.executable, "-m", "isort", "-", "--filename", str(target)],
+        input=source,
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# The exact case reported in #712
+# ---------------------------------------------------------------------------
+
+
+def test_reported_repro_round_trips_exactly(tmp_path):
+    source = (
+        "from bpy.props import (  # pyright: ignore[reportMissingModuleSource]\n"
+        "    BoolProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    EnumProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    StringProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        ")\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+
+    # Sanity check: confirm isort's real output is still the buggy shape
+    # this workaround targets. If this assertion starts failing, isort
+    # has likely fixed the bug upstream (see module docstring).
+    assert "from bpy.props import \\\n" in isort_output
+
+    repaired = fix.repair_comment_placement(source, isort_output)
+    assert repaired == source
+
+
+# ---------------------------------------------------------------------------
+# Reordering, surrounding imports, aliases
+# ---------------------------------------------------------------------------
+
+
+def test_reorders_names_and_keeps_surrounding_imports(tmp_path):
+    source = (
+        "import os\n"
+        "\n"
+        "from bpy.props import (  # pyright: ignore[reportMissingModuleSource]\n"
+        "    StringProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    BoolProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    EnumProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        ")\n"
+        "import sys\n"
+        "\n"
+        "print(os, sys, BoolProperty, EnumProperty, StringProperty)\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+    assert "from bpy.props import \\\n" in isort_output  # bug still firing
+
+    repaired = fix.repair_comment_placement(source, isort_output)
+
+    assert "import os\nimport sys\n" in repaired
+    assert (
+        "from bpy.props import (  # pyright: ignore[reportMissingModuleSource]\n"
+        "    BoolProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    EnumProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    StringProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        ")\n"
+    ) in repaired
+    assert "print(os, sys, BoolProperty, EnumProperty, StringProperty)" in repaired
+    # No leftover backslash-continuation lines.
+    assert "\\\n" not in repaired
+
+
+def test_aliases_and_mixed_commented_names(tmp_path):
+    source = (
+        "from bpy.props import (\n"
+        "    StringProperty as SP,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    BoolProperty,\n"
+        "    EnumProperty as EP,  # noqa\n"
+        ")\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+    repaired = fix.repair_comment_placement(source, isort_output)
+
+    assert "BoolProperty," in repaired
+    assert "EnumProperty as EP,  # noqa" in repaired
+    assert "StringProperty as SP,  # pyright: ignore[reportUnknownVariableType]" in repaired
+
+
+# ---------------------------------------------------------------------------
+# Safety: must be a no-op whenever the bug doesn't apply
+# ---------------------------------------------------------------------------
+
+
+def test_noop_when_no_comments_present(tmp_path):
+    source = (
+        "import sys\n"
+        "import os\n"
+        "from collections import (\n"
+        "    OrderedDict,\n"
+        "    defaultdict,\n"
+        ")\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+    assert fix.repair_comment_placement(source, isort_output) == isort_output
+
+
+def test_noop_on_non_import_file(tmp_path):
+    source = "x = 1\ny = 2\n"
+    isort_output = _run_isort(source, tmp_path)
+    assert fix.repair_comment_placement(source, isort_output) == isort_output
+
+
+def test_noop_when_isort_output_unchanged_by_profile(tmp_path):
+    # A `profile = "black"` config (this repo's own pyproject.toml is a
+    # real example) makes isort wrap differently and doesn't hit the
+    # buggy code path -- repair_comment_placement must leave that
+    # untouched rather than "fixing" something that wasn't broken.
+    (tmp_path / "pyproject.toml").write_text('[tool.isort]\nprofile = "black"\n')
+    source = (
+        "from bpy.props import (  # pyright: ignore[reportMissingModuleSource]\n"
+        "    StringProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    BoolProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    EnumProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        ")\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+    assert "\\\n" not in isort_output  # confirm the bug didn't fire here
+    assert fix.repair_comment_placement(source, isort_output) == isort_output
+
+
+def test_noop_on_empty_and_trivial_input():
+    assert fix.repair_comment_placement("", "") == ""
+    assert fix.repair_comment_placement("import os\n", "import os\n") == "import os\n"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent(tmp_path):
+    source = (
+        "from bpy.props import (  # pyright: ignore[reportMissingModuleSource]\n"
+        "    BoolProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    EnumProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        "    StringProperty,  # pyright: ignore[reportUnknownVariableType]\n"
+        ")\n"
+    )
+    isort_output = _run_isort(source, tmp_path)
+    repaired_once = fix.repair_comment_placement(source, isort_output)
+    isort_output_again = _run_isort(repaired_once, tmp_path)
+    repaired_twice = fix.repair_comment_placement(repaired_once, isort_output_again)
+    assert repaired_once == repaired_twice


### PR DESCRIPTION
isort mishandles trailing inline comments (e.g. pyright: ignore) on
names in a parenthesized multi-import block when it has to re-wrap
the block, misplacing them onto the wrong import. This only fires
when the target file exists on disk at the path isort is given,
which is always true for real editor usage.

Adds isort_comment_fix.repair_comment_placement, called from
_formatting_helper after isort runs. It cross-references isort's
output against the original source and rebuilds any affected block
with comments correctly reattached, using isort's own chosen name
order so no real sorting decision is overridden. No-op for every
file that doesn't hit this exact shape.

8 new regression tests in test_isort_comment_fix.py, run against
the real isort CLI.

Fixes #712.