### PR TITLE
Remove dependencies provided by shared package

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ npm run vsce-package-pre      # Build .vsix for pre-release
 - **Settings resolution:** `src/common/settings.ts` resolves VS Code variables (`${workspaceFolder}`, `${fileDirname}`, `${interpreter}`, `${env:*}`) in user-provided settings arrays. It also handles legacy `python.sortImports.*` settings with deprecation logging.
 - **Server info from package.json:** The `serverInfo` field in `package.json` (`{ name, module }`) drives the server ID and module name throughout both the client and server code. Changes there propagate automatically.
 - **Copyright header:** All source files start with `// Copyright (c) Microsoft Corporation. All rights reserved.` (TS) or `# Copyright (c) Microsoft Corporation. All rights reserved.` (Python), followed by the MIT license line.
-- **Dependency management:** `nox -s update_packages` updates both pip and npm dependencies. Some npm packages are pinned (`vscode-languageclient`, `@types/vscode`, `@types/node`).
+- **Dependency management:** `nox -s update_packages` updates both pip and npm dependencies. Some npm packages are pinned (`@types/vscode`, `@types/node`).
 
 ## Development Guidelines
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
-    exclude-patterns:
-      - 'isort'
     labels:
       - 'dependencies'
       - 'debt'
@@ -38,6 +36,8 @@ updates:
       - '/src/test/python_tests'
     patterns:
       - '*'
+    exclude-patterns:
+      - 'isort'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 
+registries:
+  pylance-public-packages:
+    type: npm-registry
+    url: https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/
+    tenant-id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+    client-id: 92c669e8-02ad-4ce6-ad73-f222fc7177e2
+    replaces-base: true
+
 multi-ecosystem-groups:
   dependencies:
     schedule:
@@ -13,6 +21,7 @@ multi-ecosystem-groups:
 updates:
   # NPM, Python, and GitHub Actions dependencies are updated together.
   - package-ecosystem: 'npm'
+    registries: '*'
     labels:
       - 'dependencies'
       - 'debt'
@@ -21,8 +30,6 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    cooldown:
-      default-days: 7
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
   dependencies:
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 10
     labels:
       - 'dependencies'
       - 'debt'
@@ -22,7 +23,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
@@ -57,7 +57,6 @@ updates:
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
 
   # The shared package submodule is updated daily in a standalone PR.
   - package-ecosystem: 'gitsubmodule'
@@ -81,4 +80,3 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,26 @@ updates:
     directories:
       - '/'
       - '/src/test/python_tests'
+    # Multi-ecosystem groups only support positive patterns. Keep isort
+    # unmatched so its updates remain standalone.
     patterns:
-      - '*'
-    exclude-patterns:
-      - 'isort'
+      - 'attrs'
+      - 'cattrs'
+      - 'colorama'
+      - 'exceptiongroup'
+      - 'iniconfig'
+      - 'lsprotocol'
+      - 'mypy-extensions'
+      - 'packaging'
+      - 'pluggy'
+      - 'pygls'
+      - 'pygments'
+      - 'pyhamcrest'
+      - 'pytest'
+      - 'python-lsp-jsonrpc'
+      - 'tomli'
+      - 'typing-extensions'
+      - 'ujson'
     multi-ecosystem-group: 'dependencies'
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'
-      - dependency-name: 'vscode-languageclient'
 
   - package-ecosystem: 'pip'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,8 @@ multi-ecosystem-groups:
 updates:
   # NPM, Python, and GitHub Actions dependencies are updated together.
   - package-ecosystem: 'npm'
-    registries: '*'
+    registries:
+      - 'pylance-public-packages'
     labels:
       - 'dependencies'
       - 'debt'
@@ -30,6 +31,8 @@ updates:
     patterns:
       - '*'
     multi-ecosystem-group: 'dependencies'
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: '@types/vscode'
       - dependency-name: '@types/node'

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry=https://registry.npmjs.org/
-# Do not require auth for public installs
-always-auth=false

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,6 @@ def _get_package_data(package):
 
 def _update_npm_packages(session: nox.Session) -> None:
     pinned = {
-        "vscode-languageclient",
         "@types/vscode",
         "@types/node",
         "@vscode/common-python-lsp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-                "@vscode/python-extension": "^1.0.5",
-                "vscode-languageclient": "^8.1.0"
+                "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.5",

--- a/package.json
+++ b/package.json
@@ -209,9 +209,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript",
-        "@vscode/python-extension": "^1.0.5",
-        "vscode-languageclient": "^8.1.0"
+        "@vscode/common-python-lsp": "file:external/vscode-common-python-lsp/typescript"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.5",


### PR DESCRIPTION
## Summary  - remove extension-level npm dependencies already provided by `@vscode/common-python-lsp`  - keep dependencies still imported by extension-owned source or tests - remove stale dependency-update exclusions where the shared package now owns the dependency   ## Dependabot configuration  - use supported positive `patterns` to group all currently locked non-tool Python dependencies - leave the primary tool unmatched so its updates remain standalone  - set the pull request limit on the multi-ecosystem group, as required by Dependabot's schema 

## Approved npm feed

- use the OIDC-authenticated `Pylance_PublicPackages` registry explicitly for Dependabot npm updates
- retain the seven-day npm cooldown because `@vscode/python-environments` still uses an explicit feed URL
- remove the project `.npmrc` so it does not override Dependabot's configured registry

Keep `no-merge` until the identity has repository-specific federation and feed-reader access.